### PR TITLE
add server_address to Client, example println when connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Received connection
 
 and then the client prints:
 ```
+Connected to server: 127.0.0.1:10500
 response: Response { body: b"", reason_phrase: ReasonPhrase("OK"), headers: {CSeq: HeaderValue("292131050"), Date: HeaderValue("Sat, 29 Jun 2019 14:25:13 +0000")}, status_code: 200, version: RTSP/2.0 }
 ```
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -24,6 +24,8 @@ fn main() {
             Err(())
         })
         .and_then(|mut client| {
+            println!("Connected to server: {}", client.server_address);
+
             let mut builder = Request::builder();
             builder
                 .method(Method::Setup)

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -24,7 +24,8 @@ fn main() {
             Err(())
         })
         .and_then(|mut client| {
-            println!("Connected to server: {}", client.server_address);
+            let addr = client.server_address();
+            println!("Connected to server: {}", addr);
 
             let mut builder = Request::builder();
             builder

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,6 @@ pub struct Client {
 
 impl Client {
     pub fn connect(server_address: SocketAddr) -> impl Future<Item = Client, Error = io::Error> {
-
         TcpStream::connect(&server_address).and_then(move |tcp_stream| {
             let mut executor = DefaultExecutor::current();
             let (connection, handler, handle) = Connection::new::<EmptyService>(tcp_stream, None);
@@ -27,7 +26,10 @@ impl Client {
             if let Some(handler) = handler {
                 executor.spawn(Box::new(handler)).unwrap();
             }
-            Ok(Client { handle,  server_address })
+            Ok(Client {
+                handle,
+                server_address,
+            })
         })
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,9 +33,8 @@ impl Client {
         })
     }
 
-    pub fn server_address(&self) -> SocketAddr {
-        let addr: SocketAddr = self.server_address.clone();
-        return addr;
+    pub fn server_address(&self) -> &SocketAddr {
+        &self.server_address
     }
 
     pub fn send_request<R, B>(


### PR DESCRIPTION
I don't quite have enough context with the structure of this package to know whether
this is the best approach.  I was experimenting with making a different RTSP connection
and got an error (`error sending request: request cancelled`), so I thought to add a modest
improvement to print that the connection succeeded with the address that it connected to.

I thought about exposing a `peer_address()` method and keeping a private reference to TcpStream or perhaps it would be better to make available from the `ConnectionHandle`

I'm new to Rust, and welcome all feedback or alternate suggested implementation.