### PR TITLE
extend example to allow for user input for server address

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -9,6 +9,7 @@ use rtsp::client::Client;
 use rtsp::method::Method;
 use rtsp::request::Request;
 use rtsp::uri::request::URI;
+use rtsp::uri::{Authority,Path,Scheme};
 use std::convert::TryFrom;
 use std::net::SocketAddr;
 
@@ -34,10 +35,20 @@ fn main() {
             let addr = client.server_address();
             println!("Connected to server: {}", addr);
 
+            let ip_str = client.server_address
+                            .ip().to_string();
+            let authority = Authority::try_from(ip_str.as_str()).unwrap();
+            let uri = URI::builder()
+                .with_scheme(Scheme::RTSP)
+                .with_authority(authority)
+                .with_path(Path::try_from("").unwrap())
+                .build()
+                .unwrap();
+
             let mut builder = Request::builder();
             builder
                 .method(Method::Setup)
-                .uri(URI::try_from("rtsp://127.0.0.1/").unwrap())
+                .uri(uri)
                 .body(BytesMut::new());
             let request = builder.build().unwrap();
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -12,8 +12,15 @@ use rtsp::uri::request::URI;
 use std::convert::TryFrom;
 use std::net::SocketAddr;
 
+
 fn main() {
-    let address = "127.0.0.1:10500".parse::<SocketAddr>().unwrap();
+    let input: Option<String> = std::env::args().nth(1);
+    let  address_str: &str = match input {
+        None => "127.0.0.1:10500",
+        Some(ref addr) => addr.as_str(),
+    };
+    let address = address_str.parse::<SocketAddr>().unwrap();
+    println!("Initiating connection to: {}", address);
 
     // Connect to the server. Currently, any requests sent by the server will be ignored by the
     // client. An API to support handling these requests will be added soonish.


### PR DESCRIPTION
Submitting for review and feedback,,,

In retrospect, the example was much easier to understand
with hard-coded strings.  Or maybe I just don't know how to use `URI::builder` to make the
code more readable. Creating a string from the IP address and then calling URI::try_from
would be more concise (and maybe ok for this simply case), but I'd like to figure out a pattern
that would be good for all the requests.

This may be better as a separate example (perhaps extended to vary the kinds of requests it makes).  Though maybe you want less example code while the library is still in early development. 